### PR TITLE
Fixing blobid case

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/griffon-toolkit-common",
   "description": "Common Data Structures and Events used by Griffon",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/griffon-toolkit.git",

--- a/packages/common/schemas/screenshotResponse.json
+++ b/packages/common/schemas/screenshotResponse.json
@@ -9,7 +9,7 @@
       "inherit": true,
       "type": "object",
       "properties": {
-        "blobid": {
+        "blobId": {
           "description": "ID returned from the blob service",
           "type": "string",
           "mock": "abcdefg"

--- a/packages/common/src/screenshotResponse.js
+++ b/packages/common/src/screenshotResponse.js
@@ -21,7 +21,7 @@ import schema from '../schemas/screenshotResponse.json';
  * ```
  * {
  *   payload: {
- *     blobid: <string>,
+ *     blobId: <string>,
  *     mimeType: <string>,
  *   },
  *   type: 'blob'
@@ -53,8 +53,8 @@ const path = {
   /** An object with custom data describing the event.<br />Path is `payload`. */
   payload: 'payload',
 
-  /** ID returned from the blob service.<br />Path is `payload.blobid`. */
-  blobid: 'payload.blobid',
+  /** ID returned from the blob service.<br />Path is `payload.blobId`. */
+  blobId: 'payload.blobId',
 
   /** Describes the type of blob content uploaded.<br />Path is `payload.mimeType`. */
   mimeType: 'payload.mimeType',
@@ -113,16 +113,16 @@ const ROOT_TYPE = 'blob';
 const get = kit.curry((alias, data) => kit.search(path[alias] || alias, data));
 
 /**
- * Returns the `blobid` from the Screenshot Response Event.
+ * Returns the `blobId` from the Screenshot Response Event.
  * This is the iD returned from the blob service.
  *
- * Path is `payload.blobid`.
+ * Path is `payload.blobId`.
  *
  * @function
  * @param {object} source The Screenshot Response Event instance
  * @returns {string}
  */
-const getBlobid = kit.search(path.blobid);
+const getBlobId = kit.search(path.blobId);
 
 /**
  * Returns the `mimeType` from the Screenshot Response Event.
@@ -182,7 +182,7 @@ const make = (input) => kit.expandWithPaths(path, {
  * @returns {object}
  */
 const mock = (input) => kit.expandWithPaths(path, {
-  blobid: 'abcdefg',
+  blobId: 'abcdefg',
   mimeType: 'images/jpg',
   rootType: 'blob',
   clientId: 'appleABC',
@@ -199,7 +199,7 @@ export default {
   schema,
   get,
   ...customExports,
-  getBlobid,
+  getBlobId,
   getMimeType,
   isMatch,
   matcher,


### PR DESCRIPTION
## Description

On the `screenshotResponse` events, the SDK is sending `blobId` rather than `blobid`. So we are fixing that.

## How Has This Been Tested?

No tests needed

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
