### PR TITLE
Fix a couple schemas

### DIFF
--- a/packages/aep-mobile/package.json
+++ b/packages/aep-mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/griffon-toolkit-aep-mobile",
   "description": "Events definitions for the AEP Mobile SDK",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/griffon-toolkit.git",

--- a/packages/aep-mobile/schemas/mobileEvent.json
+++ b/packages/aep-mobile/schemas/mobileEvent.json
@@ -51,7 +51,8 @@
     },
     "type": {
       "inherit": true,
-      "const": "generic"
+      "const": "generic",
+      "match": false
     },
     "vendor": {
       "description": "The vendor of the plugin that sent the event",

--- a/packages/aep-mobile/schemas/sharedState.json
+++ b/packages/aep-mobile/schemas/sharedState.json
@@ -14,7 +14,7 @@
           "type": "object",
           "description": "The full list of current configuration values",
           "properties": {
-            "state.owner": {
+            "stateowner": {
               "alias": "stateOwner",
               "description": "In SDK extension that owns the shared state that is being updated",
               "type": "string",

--- a/packages/aep-mobile/schemas/sharedStateVersions.json
+++ b/packages/aep-mobile/schemas/sharedStateVersions.json
@@ -9,6 +9,16 @@
       "inherit": true,
       "type": "object",
       "properties": {
+        "ACPExtensionEventData": {
+          "inherit": true,
+          "type": "object",
+          "properties": {
+            "stateowner": {
+              "inherit": true,
+              "const": "com.adobe.module.eventhub"
+            }
+          }
+        },
         "metadata": {
           "inherit": true,
           "type": "object",
@@ -25,6 +35,7 @@
                 "extensions": {
                   "description": "A mapping of versions per sdk extension",
                   "type": "object",
+                  "match": true,
                   "mock": "{ Lifecycle: '2.4.0', 'com.adobe.ACPGriffon': '2.0.0' }"
                 }
               },

--- a/packages/aep-mobile/schemas/startPlacesMonitor.json
+++ b/packages/aep-mobile/schemas/startPlacesMonitor.json
@@ -15,7 +15,7 @@
         },
         "ACPExtensionEventType": {
           "inherit": true,
-          "const": "com.adobe.eventType.placesMonitor"
+          "const": "com.adobe.eventtype.placesmonitor"
         }
       }
     }

--- a/packages/aep-mobile/src/analyticsResponse.js
+++ b/packages/aep-mobile/src/analyticsResponse.js
@@ -245,7 +245,6 @@ const getHitHost = kit.search(path.hitHost);
 const matcher = kit.combineAll([
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.responsecontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.analytics\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/configuration.js
+++ b/packages/aep-mobile/src/configuration.js
@@ -240,7 +240,6 @@ const getRulesUrl = kit.search(path.rulesUrl);
 const matcher = kit.combineAll([
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.responsecontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.configuration\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/configurationUpdate.js
+++ b/packages/aep-mobile/src/configurationUpdate.js
@@ -180,7 +180,6 @@ const getConfigDataKey = kit.curry(
 const matcher = kit.combineAll([
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.requestcontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.configuration\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/genericPlaces.js
+++ b/packages/aep-mobile/src/genericPlaces.js
@@ -141,7 +141,6 @@ const get = R.curry((alias, data) => kit.search(path[alias] || alias, data));
 const matcher = kit.combineAll([
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.places\'',
   'payload.ACPExtensionEventSource',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/genericTrack.js
+++ b/packages/aep-mobile/src/genericTrack.js
@@ -180,7 +180,6 @@ const getContextDataKey = kit.curry(
 const matcher = kit.combineAll([
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.requestcontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.generic.track\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/lifecycleStart.js
+++ b/packages/aep-mobile/src/lifecycleStart.js
@@ -533,7 +533,6 @@ const getPreviousSessionStartTimestamp = kit.search(path.previousSessionStartTim
 const matcher = kit.combineAll([
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.responsecontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.lifecycle\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/locationAuthStatus.js
+++ b/packages/aep-mobile/src/locationAuthStatus.js
@@ -193,7 +193,6 @@ const matcher = kit.combineAll([
   'payload.ACPExtensionEventData.requesttype==\'requestsetauthorizationstatus\'',
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.requestcontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.places\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/mobileEvent.js
+++ b/packages/aep-mobile/src/mobileEvent.js
@@ -229,7 +229,6 @@ const getVendor = kit.search(path.vendor);
 const matcher = kit.combineAll([
   'payload.ACPExtensionEventSource',
   'payload.ACPExtensionEventType',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/placesEntry.js
+++ b/packages/aep-mobile/src/placesEntry.js
@@ -276,7 +276,6 @@ const matcher = kit.combineAll([
   'payload.ACPExtensionEventData.regioneventtype==\'entry\'',
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.responsecontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.places\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/placesExit.js
+++ b/packages/aep-mobile/src/placesExit.js
@@ -276,7 +276,6 @@ const matcher = kit.combineAll([
   'payload.ACPExtensionEventData.regioneventtype==\'exit\'',
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.responsecontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.places\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/receivePlaces.js
+++ b/packages/aep-mobile/src/receivePlaces.js
@@ -193,7 +193,6 @@ const matcher = kit.combineAll([
   'payload.ACPExtensionEventData.nearbypois',
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.responsecontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.places\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/requestPlaces.js
+++ b/packages/aep-mobile/src/requestPlaces.js
@@ -250,7 +250,6 @@ const matcher = kit.combineAll([
   'payload.ACPExtensionEventData.requesttype==\'requestgetnearbyplaces\'',
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.requestcontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.places\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/sharedState.js
+++ b/packages/aep-mobile/src/sharedState.js
@@ -22,7 +22,7 @@ import schema from '../schemas/sharedState.json';
  * {
  *   payload: {
  *     ACPExtensionEventData: {
- *       state.owner: <string>,
+ *       stateowner: <string>,
  *     },
  *     ACPExtensionEventSource: 'com.adobe.eventsource.sharedstate'
  *     ACPExtensionEventType: 'com.adobe.eventtype.hub'
@@ -57,8 +57,8 @@ const path = {
   /** The full list of current configuration values.<br />Path is `payload.ACPExtensionEventData`. */
   eventData: 'payload.ACPExtensionEventData',
 
-  /** In SDK extension that owns the shared state that is being updated.<br />Path is `payload.ACPExtensionEventData."state.owner"`. */
-  stateOwner: 'payload.ACPExtensionEventData."state.owner"',
+  /** In SDK extension that owns the shared state that is being updated.<br />Path is `payload.ACPExtensionEventData.stateowner`. */
+  stateOwner: 'payload.ACPExtensionEventData.stateowner',
 
   /** The event source.<br />Path is `payload.ACPExtensionEventSource`. */
   eventSource: 'payload.ACPExtensionEventSource',
@@ -159,7 +159,7 @@ const get = R.curry((alias, data) => kit.search(path[alias] || alias, data));
  * Returns the `stateOwner` from the Shared State Event.
  * This is the in SDK extension that owns the shared state that is being updated.
  *
- * Path is `payload,ACPExtensionEventData,state.owner`.
+ * Path is `payload,ACPExtensionEventData,stateowner`.
  *
  * @function
  * @param {object} source The Shared State Event instance
@@ -201,7 +201,6 @@ const getStateDataKey = kit.curry(
 const matcher = kit.combineAll([
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.sharedstate\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.hub\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/sharedStateVersions.js
+++ b/packages/aep-mobile/src/sharedStateVersions.js
@@ -21,14 +21,14 @@ import schema from '../schemas/sharedStateVersions.json';
  * ```
  * {
  *   payload: {
+ *     ACPExtensionEventData: {
+ *       stateowner: 'com.adobe.module.eventhub'
+ *     },
  *     metadata: {
  *       state.data: {
  *         version: <string>,
  *         extensions: <object>,
  *       },
- *     },
- *     ACPExtensionEventData: {
- *       state.owner: <string>,
  *     },
  *     ACPExtensionEventSource: 'com.adobe.eventsource.sharedstate'
  *     ACPExtensionEventType: 'com.adobe.eventtype.hub'
@@ -57,6 +57,12 @@ const path = {
   /** An object with custom data describing the event.<br />Path is `payload`. */
   payload: 'payload',
 
+  /** The full list of current configuration values.<br />Path is `payload.ACPExtensionEventData`. */
+  eventData: 'payload.ACPExtensionEventData',
+
+  /** In SDK extension that owns the shared state that is being updated.<br />Path is `payload.ACPExtensionEventData.stateowner`. */
+  stateOwner: 'payload.ACPExtensionEventData.stateowner',
+
   /** Additional metadata that is attacked to SDK events.<br />Path is `payload.metadata`. */
   metadata: 'payload.metadata',
 
@@ -68,12 +74,6 @@ const path = {
 
   /** A mapping of versions per sdk extension.<br />Path is `payload.metadata."state.data".extensions`. */
   extensions: 'payload.metadata."state.data".extensions',
-
-  /** The full list of current configuration values.<br />Path is `payload.ACPExtensionEventData`. */
-  eventData: 'payload.ACPExtensionEventData',
-
-  /** In SDK extension that owns the shared state that is being updated.<br />Path is `payload.ACPExtensionEventData."state.owner"`. */
-  stateOwner: 'payload.ACPExtensionEventData."state.owner"',
 
   /** The event source.<br />Path is `payload.ACPExtensionEventSource`. */
   eventSource: 'payload.ACPExtensionEventSource',
@@ -126,6 +126,15 @@ const label = 'Shared State - Versions';
  * A grouping for this object
  */
 const group = 'event';
+
+/**
+ * The value for `stateOwner` for a Shared State - Versions.
+ *
+ * Path is `payload,ACPExtensionEventData,stateowner`.
+ *
+ * @constant
+ */
+const STATE_OWNER = 'com.adobe.module.eventhub';
 
 /**
  * The value for `eventSource` for a Shared State - Versions.
@@ -208,9 +217,10 @@ const getExtensionsKey = kit.curry(
  * @constant
  */
 const matcher = kit.combineAll([
+  'payload.ACPExtensionEventData.stateowner==\'com.adobe.module.eventhub\'',
+  'payload.metadata."state.data".extensions',
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.sharedstate\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.hub\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 
@@ -233,6 +243,7 @@ const isMatch = (source) => kit.isMatch(matcher, source);
  * @returns {object}
  */
 const make = (input) => kit.expandWithPaths(path, {
+  stateOwner: 'com.adobe.module.eventhub',
   eventSource: 'com.adobe.eventsource.sharedstate',
   eventType: 'com.adobe.eventtype.hub',
   rootType: 'generic',
@@ -250,10 +261,10 @@ const make = (input) => kit.expandWithPaths(path, {
  * @returns {object}
  */
 const mock = (input) => kit.expandWithPaths(path, {
+  stateOwner: 'com.adobe.module.eventhub',
   stateData: { version: '2.1.3' },
   sdkVersion: '2.7.1',
   extensions: { Lifecycle: '2.4.0', 'com.adobe.ACPGriffon': '2.0.0' },
-  stateOwner: 'com.adobe.mobule.eventhub',
   eventSource: 'com.adobe.eventsource.sharedstate',
   eventType: 'com.adobe.eventtype.hub',
   rootType: 'generic',
@@ -284,6 +295,7 @@ export default {
   getExtensionsKey,
   isMatch,
   matcher,
+  STATE_OWNER,
   EVENT_SOURCE,
   EVENT_TYPE,
   ROOT_TYPE,

--- a/packages/aep-mobile/src/startPlacesMonitor.js
+++ b/packages/aep-mobile/src/startPlacesMonitor.js
@@ -22,7 +22,7 @@ import schema from '../schemas/startPlacesMonitor.json';
  * {
  *   payload: {
  *     ACPExtensionEventSource: 'com.adobe.eventsource.requestcontent'
- *     ACPExtensionEventType: 'com.adobe.eventType.placesMonitor'
+ *     ACPExtensionEventType: 'com.adobe.eventtype.placesmonitor'
  *     ACPExtensionEventData: <object>,
  *     ACPExtensionEventName: <string>,
  *     ACPExtensionEventNumber: <integer>,
@@ -120,7 +120,7 @@ const EVENT_SOURCE = 'com.adobe.eventsource.requestcontent';
  *
  * @constant
  */
-const EVENT_TYPE = 'com.adobe.eventType.placesMonitor';
+const EVENT_TYPE = 'com.adobe.eventtype.placesmonitor';
 
 /**
  * The value for `rootType` for a Start Monitor Event.
@@ -149,8 +149,7 @@ const get = R.curry((alias, data) => kit.search(path[alias] || alias, data));
  */
 const matcher = kit.combineAll([
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.requestcontent\'',
-  'payload.ACPExtensionEventType==\'com.adobe.eventType.placesMonitor\'',
-  'type==\'generic\'',
+  'payload.ACPExtensionEventType==\'com.adobe.eventtype.placesmonitor\'',
   'timestamp'
 ]);
 
@@ -174,7 +173,7 @@ const isMatch = (source) => kit.isMatch(matcher, source);
  */
 const make = (input) => kit.expandWithPaths(path, {
   eventSource: 'com.adobe.eventsource.requestcontent',
-  eventType: 'com.adobe.eventType.placesMonitor',
+  eventType: 'com.adobe.eventtype.placesmonitor',
   rootType: 'generic',
   ...input
 });
@@ -191,7 +190,7 @@ const make = (input) => kit.expandWithPaths(path, {
  */
 const mock = (input) => kit.expandWithPaths(path, {
   eventSource: 'com.adobe.eventsource.requestcontent',
-  eventType: 'com.adobe.eventType.placesMonitor',
+  eventType: 'com.adobe.eventtype.placesmonitor',
   rootType: 'generic',
   vendor: 'com.adobe.mobile.sdk',
   clientId: 'appleABC',

--- a/packages/aep-mobile/src/trackAction.js
+++ b/packages/aep-mobile/src/trackAction.js
@@ -171,7 +171,6 @@ const getAction = kit.search(path.action);
 const matcher = kit.combineAll([
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.requestcontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.generic.track\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/packages/aep-mobile/src/trackState.js
+++ b/packages/aep-mobile/src/trackState.js
@@ -171,7 +171,6 @@ const getState = kit.search(path.state);
 const matcher = kit.combineAll([
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.requestcontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.generic.track\'',
-  'type==\'generic\'',
   'timestamp'
 ]);
 

--- a/scripts/utils/generate.output.js
+++ b/scripts/utils/generate.output.js
@@ -45,7 +45,7 @@ const makePropertyProps = (property, key, path, parent) => ({
   alias: property.alias || key,
   useConst: property.const,
   useMock: property.const || property.mock,
-  useMatch: property.const || property.match,
+  useMatch: (property.const && property.match !== false) || property.match,
   parent,
   snakeName: lodash.snakeCase(property.alias || key).toUpperCase()
 });


### PR DESCRIPTION
## Description

A few more bugs found while integrating the new events:
- Fix sharedState stateowner typo
- sharedStateVersions requires `extensions` and `stateowner` to be `com.adobe.module.eventhub`
- placesMonitor type should be all lowercase
- don't require that all mobile events be a type of `generic` 

I'm not 100% sure on the last one. It helps with backwards compatibility, but all new events should have the `generic` type. Regardless, we probably don't need it for identification.

## How Has This Been Tested?
No tests needed since these are just schema changes

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
