### PR TITLE
State & Action are required in track state and action

### DIFF
--- a/packages/aep-mobile/package.json
+++ b/packages/aep-mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/griffon-toolkit-aep-mobile",
   "description": "Events definitions for the AEP Mobile SDK",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/griffon-toolkit.git",

--- a/packages/aep-mobile/schemas/trackAction.json
+++ b/packages/aep-mobile/schemas/trackAction.json
@@ -16,7 +16,8 @@
             "action": {
               "description": "The action that was triggered in the application",
               "type": "string",
-              "mock": "OrderConfirmed"
+              "mock": "OrderConfirmed",
+              "match": true
             }
           },
           "required": ["contextdata", "action"]

--- a/packages/aep-mobile/schemas/trackState.json
+++ b/packages/aep-mobile/schemas/trackState.json
@@ -16,7 +16,8 @@
             "state": {
               "description": "The state that should be tracked",
               "type": "string",
-              "mock": "NoMoneyState"
+              "mock": "NoMoneyState",
+              "match": true
             }
           },
           "required": ["contextdata", "state"]

--- a/packages/aep-mobile/src/trackAction.js
+++ b/packages/aep-mobile/src/trackAction.js
@@ -169,6 +169,7 @@ const getAction = kit.search(path.action);
  * @constant
  */
 const matcher = kit.combineAll([
+  'payload.ACPExtensionEventData.action',
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.requestcontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.generic.track\'',
   'timestamp'

--- a/packages/aep-mobile/src/trackState.js
+++ b/packages/aep-mobile/src/trackState.js
@@ -169,6 +169,7 @@ const getState = kit.search(path.state);
  * @constant
  */
 const matcher = kit.combineAll([
+  'payload.ACPExtensionEventData.state',
   'payload.ACPExtensionEventSource==\'com.adobe.eventsource.requestcontent\'',
   'payload.ACPExtensionEventType==\'com.adobe.eventtype.generic.track\'',
   'timestamp'


### PR DESCRIPTION
## Description

Track State and Track Action mobile events were matching the same thing. We needed to flag the action and state fields with a `match: true` in the schemas.

## How Has This Been Tested?

Schema changes don't require tests

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [NA] My change requires a change to the documentation.
- [NA] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [NA] I have added tests to cover my changes.
- [X] All new and existing tests passed.
