### PR TITLE
Adding in the path for xdm data

### DIFF
--- a/packages/aep-mobile/package.json
+++ b/packages/aep-mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/griffon-toolkit-aep-mobile",
   "description": "Events definitions for the AEP Mobile SDK",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/griffon-toolkit.git",

--- a/packages/aep-mobile/schemas/sharedState.json
+++ b/packages/aep-mobile/schemas/sharedState.json
@@ -42,9 +42,13 @@
               "type": "object",
               "description": "The data that is being written to shared state.",
               "mock": "{ version: '2.1.3' }"
+            },
+            "xdm.state.data": {
+              "alias": "xdm",
+              "type": "object",
+              "description": "XDM data that is being written to shared state."
             }
-          },
-          "required": [ "state.data" ]
+          }
         }
       },
       "required": [

--- a/packages/aep-mobile/src/sharedState.js
+++ b/packages/aep-mobile/src/sharedState.js
@@ -28,6 +28,7 @@ import schema from '../schemas/sharedState.json';
  *     ACPExtensionEventType: 'com.adobe.eventtype.hub'
  *     metadata: {
  *       state.data: <object>,
+ *       xdm.state.data: <object>,
  *     },
  *     ACPExtensionEventName: <string>,
  *     ACPExtensionEventNumber: <integer>,
@@ -71,6 +72,9 @@ const path = {
 
   /** The data that is being written to shared state..<br />Path is `payload.metadata."state.data"`. */
   stateData: 'payload.metadata."state.data"',
+
+  /** XDM data that is being written to shared state..<br />Path is `payload.metadata."xdm.state.data"`. */
+  xdm: 'payload.metadata."xdm.state.data"',
 
   /** The name of the event.<br />Path is `payload.ACPExtensionEventName`. */
   eventName: 'payload.ACPExtensionEventName',
@@ -193,6 +197,31 @@ const getStateDataKey = kit.curry(
 );
 
 /**
+ * Returns the `xdm` from the Shared State Event.
+ * This is the xDM data that is being written to shared state..
+ *
+ * Path is `payload,metadata,xdm.state.data`.
+ *
+ * @function
+ * @param {object} source The Shared State Event instance
+ * @returns {object}
+ */
+const getXdm = kit.search(path.xdm);
+
+/**
+ * Returns the data using the specified path from the xdm
+ * of the Shared State Event.
+ *
+ * @function
+ * @param {...string} path key in object
+ * @param {object} source The Shared State Event instance
+ * @returns {*}
+ */
+const getXdmKey = kit.curry(
+  (searchPath, source) => kit.search(`${path.xdm}.${searchPath}`, source)
+);
+
+/**
  * Matcher can be used to find matching Shared State Event objects.
  *
  * @see kit.match
@@ -270,6 +299,8 @@ export default {
   getStateOwner,
   getStateData,
   getStateDataKey,
+  getXdm,
+  getXdmKey,
   isMatch,
   matcher,
   EVENT_SOURCE,

--- a/packages/aep-mobile/src/sharedStateVersions.js
+++ b/packages/aep-mobile/src/sharedStateVersions.js
@@ -29,6 +29,7 @@ import schema from '../schemas/sharedStateVersions.json';
  *         version: <string>,
  *         extensions: <object>,
  *       },
+ *       xdm.state.data: <object>,
  *     },
  *     ACPExtensionEventSource: 'com.adobe.eventsource.sharedstate'
  *     ACPExtensionEventType: 'com.adobe.eventtype.hub'
@@ -74,6 +75,9 @@ const path = {
 
   /** A mapping of versions per sdk extension.<br />Path is `payload.metadata."state.data".extensions`. */
   extensions: 'payload.metadata."state.data".extensions',
+
+  /** XDM data that is being written to shared state..<br />Path is `payload.metadata."xdm.state.data"`. */
+  xdm: 'payload.metadata."xdm.state.data"',
 
   /** The event source.<br />Path is `payload.ACPExtensionEventSource`. */
   eventSource: 'payload.ACPExtensionEventSource',


### PR DESCRIPTION
## Description

Shared state events now support a `xdm.state.data`. Added this and made it so `state.data` is no longer a required field.

## Related Issue
MOB-14169

## How Has This Been Tested?
no tests needed

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
