### PR TITLE
Adding utilities for connectors

### DIFF
--- a/packages/core/src/connectorKit.js
+++ b/packages/core/src/connectorKit.js
@@ -25,16 +25,15 @@
  * @param {object} context Context to stringify
  * @returns {string} Stringified context
  */
-export const generateConnectionContextString = context => {
+export const generateConnectionContextString = (context) => {
   const keys = Object.keys(context).sort();
   let results = '';
-  keys.forEach(key => {
+  keys.forEach((key) => {
     if (results) { results += '<>'; }
-    results += `${key}==${context[key]}`
-  })
+    results += `${key}==${context[key]}`;
+  });
   return results;
 };
-
 
 /**
  * Takes the provided context object and returns base64 encoded representation of that object
@@ -43,7 +42,7 @@ export const generateConnectionContextString = context => {
  * @param {object} context Context to encode
  * @returns {string} Encoded context
  */
-export const generateConnectionContextHash = context => btoa(generateConnectionContextString(context));
+export const generateConnectionContextHash = (context) => btoa(generateConnectionContextString(context));
 
 /**
  * Takes the namespace and context object creates a unique id based on that data

--- a/packages/core/src/connectorKit.js
+++ b/packages/core/src/connectorKit.js
@@ -1,0 +1,63 @@
+/*
+ * ************************************************************************
+ * ADOBE CONFIDENTIAL
+ * ___________________
+ *
+ *   Copyright 2021 Adobe Systems Incorporated
+ *   All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Adobe Systems Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Adobe Systems Incorporated and its
+ * suppliers and are protected by all applicable intellectual property
+ * laws, including trade secret and copyright laws.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe Systems Incorporated.
+ * ************************************************************************
+ */
+
+/**
+ * Takes the provided context object and returns a string representation of that object
+ *
+ * @function
+ * @param {object} context Context to stringify
+ * @returns {string} Stringified context
+ */
+export const generateConnectionContextString = context => {
+  const keys = Object.keys(context).sort();
+  let results = '';
+  keys.forEach(key => {
+    if (results) { results += '<>'; }
+    results += `${key}==${context[key]}`
+  })
+  return results;
+};
+
+
+/**
+ * Takes the provided context object and returns base64 encoded representation of that object
+ *
+ * @function
+ * @param {object} context Context to encode
+ * @returns {string} Encoded context
+ */
+export const generateConnectionContextHash = context => btoa(generateConnectionContextString(context));
+
+/**
+ * Takes the namespace and context object creates a unique id based on that data
+ *
+ * @function
+ * @param {string} namespace Namespace of the connection
+ * @param {object} context Context to stringify
+ * @returns {string} unique connection id
+ */
+export const generateConnectionId = (namespace, context) => {
+  let uuid = namespace;
+
+  if (context && typeof context === 'object' && Object.keys(context).length > 0) {
+    uuid = `${namespace}:${generateConnectionContextHash(context)}`;
+  }
+  return uuid;
+};

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -13,3 +13,4 @@ governing permissions and limitations under the License.
 export * from './filterKit';
 export { curry } from 'ramda';
 export * from './kit';
+export * from './connectorKit';

--- a/packages/core/test/connectorKit.spec.js
+++ b/packages/core/test/connectorKit.spec.js
@@ -39,7 +39,6 @@ describe('generateConnectionContextHash', () => {
   });
 });
 
-
 describe('generateConnectionId', () => {
   it('returns the namespace if no context', () => {
     expect(generateConnectionId('test')).toBe('test');

--- a/packages/core/test/connectorKit.spec.js
+++ b/packages/core/test/connectorKit.spec.js
@@ -1,0 +1,54 @@
+/*
+ * ************************************************************************
+ * ADOBE CONFIDENTIAL
+ * ___________________
+ *
+ *   Copyright 2021 Adobe Systems Incorporated
+ *   All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains
+ * the property of Adobe Systems Incorporated and its suppliers,
+ * if any.  The intellectual and technical concepts contained
+ * herein are proprietary to Adobe Systems Incorporated and its
+ * suppliers and are protected by all applicable intellectual property
+ * laws, including trade secret and copyright laws.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe Systems Incorporated.
+ * ************************************************************************
+ */
+
+import {
+  generateConnectionContextHash,
+  generateConnectionContextString,
+  generateConnectionId
+} from '../src/connectorKit';
+
+describe('generateConnectionContextString', () => {
+  it('converts to a string', () => {
+    expect(generateConnectionContextString({ a: 'b', c: 'd' })).toBe('a==b<>c==d');
+  });
+  it('sorts the data', () => {
+    expect(generateConnectionContextString({ c: 'd', a: 'b' })).toBe('a==b<>c==d');
+  });
+});
+
+describe('generateConnectionContextHash', () => {
+  it('hashes the context string', () => {
+    expect(generateConnectionContextHash({ a: 'b', c: 'd' })).toBe('YT09Yjw+Yz09ZA==');
+  });
+});
+
+
+describe('generateConnectionId', () => {
+  it('returns the namespace if no context', () => {
+    expect(generateConnectionId('test')).toBe('test');
+    expect(generateConnectionId('test', {})).toBe('test');
+  });
+
+  it('encodes the context', () => {
+    expect(generateConnectionId('test', { a: 'b', c: 'd' })).toBe(
+      'test:YT09Yjw+Yz09ZA=='
+    );
+  });
+});


### PR DESCRIPTION
## Description

A Connector can have several different Connections -- each with different `context` data. For example, a connector that loads Launch Properties might have several different Connections, each with a different property id. 

We need a standard way of uniquely identifying the Connectors. Since other projects might want to do this, I've put this functionality here instead of building it directly into Dorado.

## How Has This Been Tested?

New test file added

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
