### PR TITLE
Fixing types in edgeResponse

### DIFF
--- a/packages/aep-mobile/package.json
+++ b/packages/aep-mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/griffon-toolkit-aep-mobile",
   "description": "Events definitions for the AEP Mobile SDK",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/griffon-toolkit.git",

--- a/packages/aep-mobile/schemas/edgeResponse.json
+++ b/packages/aep-mobile/schemas/edgeResponse.json
@@ -25,13 +25,13 @@
               "mock": "abc-efg"
             },
             "type": {
-              "alias": "requestType",
-              "description": "The type of request that was made",
+              "alias": "responseType",
+              "description": "The type of response being returned",
               "type": "string",
               "mock": "state:store"
             },
             "payload": {
-              "alias": "requestPayload",
+              "alias": "responsePayload",
               "description": "The information received in the response",
               "type": "array"
             }

--- a/packages/aep-mobile/src/edgeResponse.ts
+++ b/packages/aep-mobile/src/edgeResponse.ts
@@ -62,11 +62,11 @@ const path = {
   /** The event ID of the event that this is a response to.<br />Path is `payload.ACPExtensionEventData.requestEventId`. */
   requestEventId: 'payload.ACPExtensionEventData.requestEventId',
 
-  /** The type of request that was made.<br />Path is `payload.ACPExtensionEventData.type`. */
-  requestType: 'payload.ACPExtensionEventData.type',
+  /** The type of response being returned.<br />Path is `payload.ACPExtensionEventData.type`. */
+  responseType: 'payload.ACPExtensionEventData.type',
 
   /** The information received in the response.<br />Path is `payload.ACPExtensionEventData.payload`. */
-  requestPayload: 'payload.ACPExtensionEventData.payload',
+  responsePayload: 'payload.ACPExtensionEventData.payload',
 
   /** The event source.<br />Path is `payload.ACPExtensionEventSource`. */
   eventSource: 'payload.ACPExtensionEventSource',
@@ -177,8 +177,8 @@ const getRequestId = kit.search(path.requestId);
 const getRequestEventId = kit.search(path.requestEventId);
 
 /**
- * Returns the `requestType` from the AEP Edge Response.
- * This is the the type of request that was made.
+ * Returns the `responseType` from the AEP Edge Response.
+ * This is the the type of response being returned.
  *
  * Path is `payload,ACPExtensionEventData,type`.
  *
@@ -186,10 +186,10 @@ const getRequestEventId = kit.search(path.requestEventId);
  * @param {object} source The AEP Edge Response instance
  * @returns {string}
  */
-const getRequestType = kit.search(path.requestType);
+const getResponseType = kit.search(path.responseType);
 
 /**
- * Returns the `requestPayload` from the AEP Edge Response.
+ * Returns the `responsePayload` from the AEP Edge Response.
  * This is the the information received in the response.
  *
  * Path is `payload,ACPExtensionEventData,payload`.
@@ -198,7 +198,7 @@ const getRequestType = kit.search(path.requestType);
  * @param {object} source The AEP Edge Response instance
  * @returns {Array}
  */
-const getRequestPayload = kit.search(path.requestPayload);
+const getResponsePayload = kit.search(path.responsePayload);
 
 /**
  * Matcher can be used to find matching AEP Edge Response objects.
@@ -249,7 +249,7 @@ const make = (input) => kit.expandWithPaths(path, {
 const mock = (input) => kit.expandWithPaths(path, {
   requestId: 'BC123-8901-1234-AAFF-580993AC6258',
   requestEventId: 'abc-efg',
-  requestType: 'state:store',
+  responseType: 'state:store',
   eventSource: 'com.adobe.eventsource.responsecontent',
   eventType: 'com.adobe.eventtype.edge',
   rootType: 'generic',
@@ -277,8 +277,8 @@ export default {
   ...customExports,
   getRequestId,
   getRequestEventId,
-  getRequestType,
-  getRequestPayload,
+  getResponseType,
+  getResponsePayload,
   isMatch,
   matcher,
   EVENT_TYPE,

--- a/packages/aep-mobile/src/personalizationEdgeResponse.ts
+++ b/packages/aep-mobile/src/personalizationEdgeResponse.ts
@@ -56,8 +56,8 @@ const path = {
   /** An object with the custom data describing the event.<br />Path is `payload.ACPExtensionEventData`. */
   eventData: 'payload.ACPExtensionEventData',
 
-  /** The type of request that was made.<br />Path is `payload.ACPExtensionEventData.type`. */
-  requestType: 'payload.ACPExtensionEventData.type',
+  /** The type of response being returned.<br />Path is `payload.ACPExtensionEventData.type`. */
+  responseType: 'payload.ACPExtensionEventData.type',
 
   /** The request ID of the edge service request.<br />Path is `payload.ACPExtensionEventData.requestId`. */
   requestId: 'payload.ACPExtensionEventData.requestId',
@@ -66,7 +66,7 @@ const path = {
   requestEventId: 'payload.ACPExtensionEventData.requestEventId',
 
   /** The information received in the response.<br />Path is `payload.ACPExtensionEventData.payload`. */
-  requestPayload: 'payload.ACPExtensionEventData.payload',
+  responsePayload: 'payload.ACPExtensionEventData.payload',
 
   /** The event source.<br />Path is `payload.ACPExtensionEventSource`. */
   eventSource: 'payload.ACPExtensionEventSource',
@@ -121,13 +121,13 @@ const label = 'Edge Personalization Request';
 const group = 'event';
 
 /**
- * The value for `requestType` for a Edge Personalization Request.
+ * The value for `responseType` for a Edge Personalization Request.
  *
  * Path is `payload,ACPExtensionEventData,type`.
  *
  * @constant
  */
-const REQUEST_TYPE = 'personalization:decisions';
+const RESPONSE_TYPE = 'personalization:decisions';
 
 /**
  * The value for `eventType` for a Edge Personalization Request.
@@ -193,7 +193,7 @@ const isMatch = (source) => kit.isMatch(matcher, source);
  * @returns {object}
  */
 const make = (input) => kit.expandWithPaths(path, {
-  requestType: 'personalization:decisions',
+  responseType: 'personalization:decisions',
   eventType: 'com.adobe.eventtype.edge',
   rootType: 'generic',
   ...input
@@ -210,7 +210,7 @@ const make = (input) => kit.expandWithPaths(path, {
  * @returns {object}
  */
 const mock = (input) => kit.expandWithPaths(path, {
-  requestType: 'personalization:decisions',
+  responseType: 'personalization:decisions',
   requestId: 'BC123-8901-1234-AAFF-580993AC6258',
   requestEventId: 'abc-efg',
   eventSource: 'com.adobe.eventsource.responsecontent',
@@ -240,7 +240,7 @@ export default {
   ...customExports,
   isMatch,
   matcher,
-  REQUEST_TYPE,
+  RESPONSE_TYPE,
   EVENT_TYPE,
   ROOT_TYPE,
   label,

--- a/packages/aep-mobile/src/types/edgeResponse.ts
+++ b/packages/aep-mobile/src/types/edgeResponse.ts
@@ -61,7 +61,7 @@ export type EdgeResponse = {
        */
       requestEventId: string;
       /**
-       * The type of request that was made
+       * The type of response being returned
        */
       type?: string;
       /**


### PR DESCRIPTION
Fix a quick typo in the `edgeResponse` schema. `requestEventId` is correct, but type and payload should be `responseType` and `responsePayload`

## How Has This Been Tested?

No tests needed for schema updates

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
