### PR TITLE
Removing astrisk versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "build:rules": "lerna exec 'npm run build' --scope @adobe/griffon-toolkit-rules",
     "build": "npm run build:make-index && npm run build:files && npm run build:rules",
     "lint": "eslint \"**/*.js\"",
+    "sync": "npx lerna-ci synclocal local",
     "test": "jest"
   },
   "repository": {

--- a/packages/aep-mobile/package.json
+++ b/packages/aep-mobile/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/griffon-toolkit-aep-mobile",
   "description": "Events definitions for the AEP Mobile SDK",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/griffon-toolkit.git",
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "source": "src/index.js",
   "dependencies": {
-    "@adobe/griffon-toolkit": "*"
+    "@adobe/griffon-toolkit": "1.3.0"
   },
   "scripts": {
     "prebuild": "rm -rf dist && mkdir dist",

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/griffon-toolkit-common",
   "description": "Common Data Structures and Events used by Griffon",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/griffon-toolkit.git",
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "source": "src/index.js",
   "dependencies": {
-    "@adobe/griffon-toolkit": "*"
+    "@adobe/griffon-toolkit": "1.3.0"
   },
   "scripts": {
     "prebuild": "rm -rf dist && mkdir dist",

--- a/packages/edge/package.json
+++ b/packages/edge/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/griffon-toolkit-edge",
   "description": "Events definitions for the AEP Edge Services",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/griffon-toolkit.git",
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "source": "src/index.js",
   "dependencies": {
-    "@adobe/griffon-toolkit": "*"
+    "@adobe/griffon-toolkit": "1.3.0"
   },
   "scripts": {
     "prebuild": "rm -rf dist && mkdir dist",

--- a/packages/hit-debugger/package.json
+++ b/packages/hit-debugger/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/griffon-toolkit-hit-debugger",
   "description": "Events definitions for the hit debugger services",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/griffon-toolkit.git",
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "source": "src/index.js",
   "dependencies": {
-    "@adobe/griffon-toolkit": "*"
+    "@adobe/griffon-toolkit": "1.3.0"
   },
   "scripts": {
     "prebuild": "rm -rf dist && mkdir dist",

--- a/packages/push-services/package.json
+++ b/packages/push-services/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/griffon-toolkit-push-services",
   "description": "Events definitions for the push services",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/griffon-toolkit.git",
@@ -15,7 +15,7 @@
   "main": "dist/index.js",
   "source": "src/index.js",
   "dependencies": {
-    "@adobe/griffon-toolkit": "*"
+    "@adobe/griffon-toolkit": "1.3.0"
   },
   "scripts": {
     "prebuild": "rm -rf dist && mkdir dist",

--- a/packages/reference/package.json
+++ b/packages/reference/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@adobe/griffon-toolkit-reference",
   "description": "Utilities to build UIs from schema defs",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/adobe/griffon-toolkit.git",
@@ -15,10 +15,10 @@
   "main": "dist/index.js",
   "source": "src/index.js",
   "dependencies": {
-    "@adobe/griffon-toolkit-aep-mobile": "*",
-    "@adobe/griffon-toolkit-common": "*",
-    "@adobe/griffon-toolkit-edge": "*",
-    "@adobe/griffon-toolkit-push-services": "*"
+    "@adobe/griffon-toolkit-aep-mobile": "0.11.2",
+    "@adobe/griffon-toolkit-common": "0.3.3",
+    "@adobe/griffon-toolkit-edge": "0.2.2",
+    "@adobe/griffon-toolkit-push-services": "0.1.2"
   },
   "scripts": {
     "prebuild": "rm -rf dist && mkdir dist",


### PR DESCRIPTION
## Description

`yarn` doesn't really like the `*` we have in our package.json files. It locks onto a version and won't update it for anything. I'm proposing we replace those asterisks with the actual version.

Added `npm run sync` which syncs all the versions:

```
athomson@Adams-MacBook-Pro-2:~/sandbox/nova/griffon-toolkit$ npm run sync

> griffon-toolkit-root@0.3.0 sync
> npx lerna-ci synclocal local

[lerna-cli][synclocal] try to sync local packages' versions
[lerna-cli][synclocal] the following package.json files are updated:
@adobe/griffon-toolkit-reference(packages/reference)
  dependencies
    @adobe/griffon-toolkit-aep-mobile: 0.11.1 => 0.11.2
    @adobe/griffon-toolkit-common: 0.3.2 => 0.3.3
    @adobe/griffon-toolkit-edge: 0.2.1 => 0.2.2
    @adobe/griffon-toolkit-push-services: 0.1.1 => 0.1.2
[lerna-cli][synclocal] you may need run `npm install` to make changes take effect
```

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
