### PR TITLE
build: :arrow_up: updates node version for npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@master
       with:
-        node-version: 14.16.1
+        node-version: 16.18.0
     - name: install and build 
       run: |
         npm ci


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updating node version for the publish workflow, since the old version of node doesnt like the new package.json format.