### PR TITLE
fix(ci): add --no-verify-access to unblock lerna publish (EWHOAMI 403)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -36,7 +36,7 @@ jobs:
       env: # More info about the environment variables in the README
         NPM_TOKEN: ${{ secrets.ADOBE_BOT_NPM_TOKEN }} # This will be shared with your repo as an org secret
     - name: lerna publish
-      run: npx lerna publish from-package --yes
+      run: npx lerna publish from-package --yes --no-verify-access
       env: # More info about the environment variables in the README
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this as is, it's automatically generated


### PR DESCRIPTION
## Description

The `npm-publish` workflow fails at the publish step on `main`, blocking the `@adobe/griffon-toolkit-aep-mobile@0.14.0` release ([PR #60](https://github.com/adobe/griffon-toolkit/pull/60)).

**Root cause — not a dead token.** The Authenticate step's `npm whoami` succeeds (returns the bot user `adobe-admin`). The failure is in lerna 4's pre-publish access verification:

```
lerna info Verifying npm credentials
lerna http fetch GET 403 https://registry.npmjs.org/-/npm/v1/user
lerna ERR! EWHOAMI Authentication error. Use `npm whoami` to troubleshoot.
```

lerna 4 verifies access by calling the legacy `/-/npm/v1/user` endpoint, which returns **403 for npm automation/granular tokens** — a known limitation ([lerna#2788](https://github.com/lerna/lerna/issues/2788), [lerna#1574](https://github.com/lerna/lerna/issues/1574)). The token itself has publish rights; only this pre-check is incompatible.

## Fix

Add `--no-verify-access` to the `lerna publish` invocation. This skips the `/-/npm/v1/user` pre-check while leaving the actual publish authentication intact. Newer lerna versions made `--no-verify-access` the default for exactly this reason.

```diff
- run: npx lerna publish from-package --yes
+ run: npx lerna publish from-package --yes --no-verify-access
```

## How Has This Been Tested?

Verified locally as far as is possible without the org publish token (which only exists in CI):

- The pinned **lerna 4.0.0** (what CI runs after `npm ci`) accepts `--no-verify-access` — `lerna publish --help` lists it: *"Do not verify package read-write access for current npm user."*
- `@adobe/griffon-toolkit-aep-mobile@0.14.0` builds (`tsc`) and `npm pack`s cleanly — the artifact is releasable; the verify-access call was the only blocker.

The auth handshake itself can only be exercised by an actual publish run. Because the workflow uses `lerna publish from-package`, merging (or a `workflow_dispatch`) will publish **only** versions not already on the registry — i.e. just `aep-mobile@0.14.0`. Low blast radius.

## Notes

This addresses the `npm-publish` failure only. The other red checks on `main` (`Publish Docs` / GH Pages, `ci/circleci: build`) appear to be separate infra issues and are not addressed here.
